### PR TITLE
slick dot size 변경

### DIFF
--- a/css/layout6.css
+++ b/css/layout6.css
@@ -127,6 +127,10 @@ transform:translate(-50%, -50%);}
 .slick-items div{width:100%;
 height:100%;}
 
+.slick-dots li button:before {
+    font-size: 18px !important;
+}
+
 .main_slide_1, .main_slide_2{position:relative;
 z-index:2;}
 
@@ -423,5 +427,4 @@ background-color:red;}
 @media only screen and (max-width:1400px) and (min-width:1201px) {
 	.text_box .top, .text_box .bottom{font-size:5rem;}
 }
-
 


### PR DESCRIPTION
개발자 도구에서 dot css 속성 보니까 font-size로 변경하고 있길래 layout6.css에서 dot 부분에다가 font-size로 크기 조절했습니당

```
.slick-dots li button:before {
    font-size: 18px !important;
}
```

